### PR TITLE
Drop Thresholds from interventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,49 +13,28 @@ Currently under active development and will be prone to major breaking changes.
 using LimnoSES
 using Plots
 
-model = initialise(
+model = initialise(;
     experiment = Experiment(
-        identifier = "municipalities",
-        objectives = objectives(
-            objective(min_time),
-            objective(min_cost, 0.5),
+        policy = Decision(
+            target = managed_clear_eutrophic,
+            objectives = objectives(objective(min_time), objective(min_cost)),
         ),
-        nutrient_series = Dynamic(),
+        identifier = "optim",
+        nutrient_series = Constant(),
     ),
-    lake_setup = lake_initial_state(X2, Martin),
+    lake_setup = lake_initial_state(S1, Martin),
     municipalities = Dict(
         "main" => (
             Governance(
                 houseowner_type = Introverted(),
-                interventions = planner(plan(Angling)),
+                interventions = planner(plan(Planting, 1:20), plan(Trawling, 1:20)),
+                policies = policy(scan(Planting), scan(Trawling)),
             ),
             100,
         ),
-        "little" => (
-            Governance(
-                houseowner_type = Enforced(),
-                interventions = planner(
-                    plan(WastewaterTreatment),
-                    plan(Planting, 2; rate = 1.0e-3),
-                    plan(Trawling, 0:3; rate = 1.3e-3),
-                ),
-                policies = policy(scan(Planting), scan(Trawling)),
-            ),
-            10,
-        ),
-        "another" => (
-            Governance(
-                houseowner_type = Social(),
-                interventions = planner(
-                    plan(WastewaterTreatment),
-                    plan(Planting, 0:8; rate = 0.9e-3, threshold = 40.0),
-                ),
-                policies = policy(scan(Planting)),
-            ),
-            80,
-        ),
     ),
 )
+
 _, data = run!(model, agent_step!, model_step!, 100; mdata = [nutrients])
 
 discrete = model.lake.sol(0:12:365*100)

--- a/src/config.jl
+++ b/src/config.jl
@@ -191,11 +191,9 @@ end
 
 struct WastewaterTreatment <: Intervention end
 @with_kw_noshow mutable struct Planting <: Intervention
-    threshold::Float64 = 20.0
     rate::Float64 = 1e-4
 end
 @with_kw_noshow mutable struct Trawling <: Intervention
-    threshold::Float64 = 50.0
     rate::Float64 = 5e-4
 end
 @with_kw_noshow mutable struct Angling <: Intervention

--- a/src/decisions.jl
+++ b/src/decisions.jl
@@ -159,7 +159,7 @@ function apply_policies!(x, test)
             # We must do this in the order of policy range
             if haskey(municipality.policies, typeof(intervention))
                 targets = keys(municipality.policies[typeof(intervention)])
-                assign = zip(targets, Iterators.take(xs, length(targets)))
+                assign = collect(zip(targets, Iterators.take(xs, length(targets))))
                 map(t -> setproperty!(intervention, t[1], t[2]), assign)
             end
         end

--- a/src/evolve.jl
+++ b/src/evolve.jl
@@ -174,19 +174,13 @@ function aggregate_regulate!(model::ABM)
     planting = Iterators.filter(i -> i isa Planting, schedule)
     model.lake.p.pv = 0.0
     for project in planting
-        # model.lake.u[3] is vegetation
-        if model.lake.u[3] < project.threshold
-            model.lake.p.pv += project.rate
-        end
+        model.lake.p.pv += project.rate
     end
 
     trawling = Iterators.filter(i -> i isa Trawling, schedule)
     model.lake.p.tb = 0.0
     for project in trawling
-        # model.lake.u[1] is bream
-        if model.lake.u[1] > project.threshold
-            model.lake.p.tb += project.rate
-        end
+        model.lake.p.tb += project.rate
     end
 
     angling = Iterators.filter(i -> i isa Angling, schedule)

--- a/src/initialise.jl
+++ b/src/initialise.jl
@@ -160,7 +160,7 @@ function plan(::Type{I}, values::Vector{<:NamedTuple}) where {I<:Intervention}
 end
 
 """
-    policy(scan(Trawling), scan(Planting; threshold = (15.3, 60.9)))
+    policy(scan(Trawling), scan(Planting; rate = (1e-5, 2.6e-3)))
 
 Enables the decision module to alter suggested planner values, optimising the system
 state when possible. Used to set the `policies` of each [Municipality](@ref).
@@ -184,10 +184,8 @@ function scan(::Type{I}; kwargs...) where {I<:Intervention}
     return Dict{Type{<:Intervention},NamedTuple}(I => default_policy(I; kwargs...))
 end
 
-default_policy(::Type{Planting}; threshold = (5.0, 60.0), rate = (1e-3, 1e-2)) =
-    (threshold = threshold, rate = rate)
-default_policy(::Type{Trawling}; threshold = (40.0, 80.0), rate = (1e-4, 1e-2)) =
-    (threshold = threshold, rate = rate)
+default_policy(::Type{Planting}; rate = (1e-3, 1e-2)) = (rate = rate,)
+default_policy(::Type{Trawling}; rate = (1e-4, 1e-2)) = (rate = rate,)
 default_policy(::Type{Angling}; rate = (2.25e-3, 2.7e-3)) = (rate = rate,)
 
 """

--- a/test/initialise.jl
+++ b/test/initialise.jl
@@ -99,16 +99,14 @@
         @test_throws AssertionError planner(plan(Angling), plan(Angling, 7))
     end
     @testset "scan" begin
-        default_planting = (threshold = (5.0, 60.0), rate = (0.001, 0.01))
+        default_planting = (rate = (0.001, 0.01),)
         @test scan(Planting) == Dict(Planting => default_planting)
         @test LimnoSES.default_policy(Planting) == default_planting
-        @test scan(Planting; rate = (0.0, 1.0)) ==
-              Dict(Planting => (threshold = (5.0, 60.0), rate = (0.0, 1.0)))
-        default_trawling = (threshold = (40.0, 80.0), rate = (0.0001, 0.01))
+        @test scan(Planting; rate = (0.0, 1.0)) == Dict(Planting => (rate = (0.0, 1.0),))
+        default_trawling = (rate = (0.0001, 0.01),)
         @test scan(Trawling) == Dict(Trawling => default_trawling)
         @test LimnoSES.default_policy(Trawling) == default_trawling
-        @test scan(Trawling; rate = (0.0, 1.0)) ==
-              Dict(Trawling => (threshold = (40.0, 80.0), rate = (0.0, 1.0)))
+        @test scan(Trawling; rate = (0.0, 1.0)) == Dict(Trawling => (rate = (0.0, 1.0),))
         default_angling = (rate = (2.25e-3, 2.7e-3),)
         @test scan(Angling) == Dict(Angling => default_angling)
         @test LimnoSES.default_policy(Angling) == default_angling
@@ -120,7 +118,7 @@
         @test pol == plant
 
         pol = policy(scan(Planting), scan(Angling))
-        @test all(map(k->k in [Angling, Planting], collect(keys(pol))))
+        @test all(map(k -> k in [Angling, Planting], collect(keys(pol))))
     end
     @testset "objective" begin
         obj = objective(min_time)


### PR DESCRIPTION
Planting and Trawling both have historically used a `threshold`. Essentially, this was used when we had a static plan for our campaigns. Perhaps Planting would run for 10 years at rate X, but at year 5 the set of interventions was enough to achieve the objective. This would be identified by `threshold` and essentially cut off any further need for our constant rate of X per year.

Now, since decision making has been implemented, tuning rates is an aspect of targets and objectives. Thresholds are no longer needed. This PR drops them completely.